### PR TITLE
[#47]: Improve printing of Tensors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Static Analysis
+name: Build and Static Analysis
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Run Script
+    - name: Build
       shell: bash
       run: ./build.sh $(pwd)
 

--- a/src/kernels.cu
+++ b/src/kernels.cu
@@ -272,8 +272,8 @@ __global__ void matmul_kernel(float *out, float *left, float *right, int64_t l0,
   out[idx] = acc;
 }
 
-void launch_matmul(void *out, void *left, void *right, int64_t ldims[3],
-                   int64_t rdims[3], size_t total) {
+void launch_matmul(void *out, void *left, void *right, const int64_t ldims[3],
+                   const int64_t rdims[3], size_t total) {
 
   int block = 256;
   int grid = (total + block - 1) / block;

--- a/src/kernels.cuh
+++ b/src/kernels.cuh
@@ -28,8 +28,8 @@ void launch_sum_dim0(void *out, void *in, int64_t d0, int64_t rest);
 void launch_sum_dim1(void *out, void *in, int64_t d0, int64_t d1, int64_t d2);
 void launch_sum_dim2(void *out, void *in, int64_t d0, int64_t d1, int64_t d2);
 
-void launch_matmul(void *out, void *left, void *right, int64_t ldims[3],
-                   int64_t rdims[3], size_t total);
+void launch_matmul(void *out, void *left, void *right, const int64_t ldims[3],
+                   const int64_t rdims[3], size_t total);
 
 // ACTIVATIONS
 void launch_relu(void *out, void *in, size_t total);

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -117,9 +117,9 @@ void *Tensor::data() const noexcept {
 
 size_t Tensor::numel() const noexcept { return impl_->elems; }
 
-std::array<int64_t, 3> Tensor::dims() const noexcept { return impl_->sizes; }
+const std::array<int64_t, 3>& Tensor::dims() const noexcept { return impl_->sizes; }
 
-std::array<int64_t, 3> Tensor::strides() const noexcept {
+const std::array<int64_t, 3>& Tensor::strides() const noexcept {
   return impl_->strides;
 }
 
@@ -141,15 +141,15 @@ void Tensor::print_elms() const {
 
   // Could be expensive
   auto t = cpu();
-  const float *data = static_cast<const float *>(t.data());
+  const float *raw_data = static_cast<const float *>(t.data());
 
-  auto sizes = dims();
-  auto stride = strides();
+  const auto& sizes = dims();
+  const auto& stride = strides();
 
   if (ndims() == 1) {
     fmt::print("Tensor: ([");
     for (int64_t i = 0; i < sizes[0]; ++i) {
-      fmt::print("{:.4f}{}", data[i * stride[0]],
+      fmt::print("{:.4f}{}", raw_data[i * stride[0]],
                  i == sizes[0] - 1 ? "" : ",  ");
     }
     fmt::print("])\n");
@@ -158,7 +158,7 @@ void Tensor::print_elms() const {
     for (int64_t i = 0; i < sizes[0]; ++i) {
       fmt::print("[");
       for (int64_t j = 0; j < sizes[1]; ++j) {
-        fmt::print("{:.4f}{}", data[i * stride[0] + j * stride[1]],
+        fmt::print("{:.4f}{}", raw_data[i * stride[0] + j * stride[1]],
                    j == sizes[1] - 1 ? "" : ",  ");
       }
       fmt::print("{}", i == sizes[0] - 1 ? "]" : "],\n          ");
@@ -172,7 +172,7 @@ void Tensor::print_elms() const {
         fmt::print("[");
         for (int64_t k = 0; k < sizes[2]; ++k) {
           fmt::print("{:.4f}{}",
-                     data[k * stride[2] + j * stride[1] + i * stride[0]],
+                     raw_data[k * stride[2] + j * stride[1] + i * stride[0]],
                      k == sizes[2] - 1 ? "" : ",  ");
         }
         fmt::print("{}", j == sizes[1] - 1 ? "]" : "],\n           ");

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -71,8 +71,8 @@ public:
   DataType dtype() const noexcept;
   void *data() const noexcept;
   size_t numel() const noexcept;
-  std::array<int64_t, 3> dims() const noexcept;
-  std::array<int64_t, 3> strides() const noexcept;
+  const std::array<int64_t, 3>& dims() const noexcept;
+  const std::array<int64_t, 3>& strides() const noexcept;
   void print() const;
   void print_elms() const;
   size_t total_bytes() const noexcept;


### PR DESCRIPTION
Fixes #47

- strides are now element count, not byte count
- print functions are no longer `noexcept` fmt::print can throw
- we still support only up to 3D tensors, should change in the future